### PR TITLE
To fix the denylist regex from keyword plugin of detect_secrets

### DIFF
--- a/tests/test_anonymizor.py
+++ b/tests/test_anonymizor.py
@@ -9,7 +9,7 @@ from anonymizor.anonymizor import (
     is_email_address,
     is_date,
     is_password,
-    sensitive_field_name,
+    is_secret,
     redact_ipv4_address,
     remove_email,
     redact_ipv4_address,
@@ -52,12 +52,14 @@ def test_is_password() -> bool:
     assert is_password("1!!3@foobar%") is True
 
 
-def test_sensitive_field_name():
-    assert sensitive_field_name("login") is False
-    assert sensitive_field_name("password") is True
-    assert sensitive_field_name("passwd") is True
-    assert sensitive_field_name("db_passwd") is True
-    assert sensitive_field_name("db_passwd") is True
+def is_secret():
+    assert is_secret("login") is False
+    assert is_secret("username") is False
+    assert is_secret("password") is True
+    assert is_secret("passwd") is True
+    assert is_secret("db_passwd") is True
+    assert is_secret("pass") is True
+    assert is_secret("key_data") is True
 
 
 def test_remove_email():


### PR DESCRIPTION
To fix the denylist regex from keyword plugin of detect_secrets, for following:
- Secrets under `pass` and `key_data`, is currently not identified by detect_secrets readymade keyword plugin denylist regex.
- And, maintaining the regex under this lib is efficient, as anytime we want to update the regex based on requirements, we need not depend on detect_secrets lib for the update.

Also, removed the use of `is_password`, coz as discussed we'll mask any secret with `"{{ }}"` for linter to identify as play error and notify the users as needed.